### PR TITLE
Fixing validation for number and country code

### DIFF
--- a/Validator/VATValidator.php
+++ b/Validator/VATValidator.php
@@ -4,6 +4,8 @@ namespace Sparkling\VATBundle\Validator;
 
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Constraint;
+use Sparkling\VATBundle\Exception\InvalidCountryCodeException;
+use Sparkling\VATBundle\Exception\InvalidVATNumberException;
 use Sparkling\VATBundle\Exception\VATException;
 
 class VATValidator extends ConstraintValidator
@@ -24,6 +26,10 @@ class VATValidator extends ConstraintValidator
             if($value == '' || $this->vat->validate($value)) {
                 return true;
             }
+        } catch (InvalidCountryCodeException $exception) {
+            // Catch invalid country code format exception
+        } catch (InvalidVATNumberException $exception) {
+            // Catch invalid number format exception
         } catch (VATException $exception) {
             return true;
         }


### PR DESCRIPTION
When an invalid number or country code were entered, the VATValidator would incorrectly return true. I assume the return true on VATExceptions is to allow inaccessible VIES service scenarios, however this also allows invalid codes such as: GB1 or X#1

This fix allows the invalid numbers and codes to be caught and an error shown, before even checking the VIES service.
