### PR TITLE
Replace VAT country code for Greece

### DIFF
--- a/Service/VATService.php
+++ b/Service/VATService.php
@@ -8,7 +8,7 @@ use Sparkling\VATBundle\Exception\InvalidVATNumberException;
 
 class VATService
 {
-    static $validCountries = array('AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK');
+    static $validCountries = array('AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'EL', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK');
 
     public function validate($countryCode, $vatNumber = null)
     {


### PR DESCRIPTION
As seen here http://en.wikipedia.org/wiki/VAT_identification_number the VAT country code for Greece is EL, which differs from GR, its iso code.