### PR TITLE
Remove string replace.

### DIFF
--- a/Service/VATService.php
+++ b/Service/VATService.php
@@ -21,9 +21,6 @@ class VATService
             $countryCode = substr($countryCode, 0, 2);
         }
 
-        $countryCode = preg_replace('/[^a-zA-Z]/', '', $countryCode);
-        $vatNumber = preg_replace('/[^a-zA-Z0-9]/', '', $vatNumber);
-
         if (!preg_match('/^[A-Z]{2}$/', $countryCode)) {
             throw new InvalidCountryCodeException(
                 'The countrycode is not valid. It must be in format [A-Z]{2}'


### PR DESCRIPTION
$countryCode = preg_replace('/[^a-zA-Z]/', '', $countryCode);
$vatNumber = preg_replace('/[^a-zA-Z0-9]/', '', $vatNumber);

Providing any invalid value to the validate function will become valid with those two lines.

example of invalid values : 

GB198332378//=/=/=/=/=*;

All the non A-Z0-9 characters will be removed and the InvalidVATNumberException will not be fired.
This value will be considered as a Valid EU VAT Number while it shouldn't.