### PR TITLE
Added php-soat requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0|~3.0"
+        "symfony/framework-bundle": ">=2.0|~3.0",
+        "ext-soap": "*"
     },
 
     "autoload": {


### PR DESCRIPTION
I suggest we add this requirements because `\SoapClient` class would be undefined on a server where the soap php extension is not installed/enabled (it actually happened to me in production environment).

